### PR TITLE
fix: deterministic, portable codegen output

### DIFF
--- a/examples/simple/src/queries.gen.d.ts
+++ b/examples/simple/src/queries.gen.d.ts
@@ -2,7 +2,7 @@
 // Run the generator to refresh.
 
 /** Result of query `GetUserDeals`. */
-interface IGetUserDealsResult {
+export interface IGetUserDealsResult {
     id: string;
     email: string;
     display_name: string | null;
@@ -11,14 +11,14 @@ interface IGetUserDealsResult {
 }
 
 /** Result of query `ListDeals`. */
-interface IListDealsResult {
+export interface IListDealsResult {
     id: string;
     status: string;
     amount: string;
 }
 
 /** Result of query `GetDealSummaries`. */
-interface IGetDealSummariesResult {
+export interface IGetDealSummariesResult {
     id: string;
     status: string;
     email: string;
@@ -29,7 +29,7 @@ interface IGetDealSummariesResult {
 }
 
 /** Result of query `ListDealDetails`. */
-interface IListDealDetailsResult {
+export interface IListDealDetailsResult {
     deal_id: string;
     status: string;
     amount: string;
@@ -39,20 +39,20 @@ interface IListDealDetailsResult {
 }
 
 /** Result of query `SearchDeals`. */
-interface ISearchDealsResult {
+export interface ISearchDealsResult {
     id: string;
     status: string;
     amount: string;
 }
 
 /** Result of query `RecentDeals`. */
-interface IRecentDealsResult {
+export interface IRecentDealsResult {
     id: string;
     status: string;
 }
 
 /** Result of query `GetDealMeta`. */
-interface IGetDealMetaResult {
+export interface IGetDealMetaResult {
     id: string;
     stage: "lead" | "negotiation" | "won" | "lost";
     tags: string[];
@@ -65,7 +65,7 @@ interface IGetDealMetaResult {
 }
 
 /** Result of query `GetDealDetails`. */
-interface IGetDealDetailsResult {
+export interface IGetDealDetailsResult {
     id: string;
     /** Free-form metadata captured during the deal. */
     details: {
@@ -75,7 +75,7 @@ interface IGetDealDetailsResult {
 }
 
 /** Result of query `CountDeals`. */
-interface ICountDealsResult {
+export interface ICountDealsResult {
     total: string | null;
 }
 

--- a/examples/sqlite/src/queries.gen.d.ts
+++ b/examples/sqlite/src/queries.gen.d.ts
@@ -2,7 +2,7 @@
 // Run the generator to refresh.
 
 /** Result of query `ListDeals`. */
-interface IListDealsResult {
+export interface IListDealsResult {
     id: number;
     status: string;
     amount: number;
@@ -10,7 +10,7 @@ interface IListDealsResult {
 }
 
 /** Result of query `GetDeal`. */
-interface IGetDealResult {
+export interface IGetDealResult {
     id: number;
     amount: number;
     attachment: Uint8Array | null;
@@ -18,26 +18,26 @@ interface IGetDealResult {
 }
 
 /** Result of query `GetUserDeals`. */
-interface IGetUserDealsResult {
+export interface IGetUserDealsResult {
     id: number | null;
     email: string | null;
     amount: number | null;
 }
 
 /** Result of query `UserEmails`. */
-interface IUserEmailsResult {
+export interface IUserEmailsResult {
     email: string;
     amount: number | null;
 }
 
 /** Result of query `DealStats`. */
-interface IDealStatsResult {
+export interface IDealStatsResult {
     total: number | null;
     loud: unknown | null;
 }
 
 /** Result of query `SearchDeals`. */
-interface ISearchDealsResult {
+export interface ISearchDealsResult {
     id: number;
     status: string;
     amount: number;

--- a/examples/with-config/src/queries.gen.d.ts
+++ b/examples/with-config/src/queries.gen.d.ts
@@ -2,7 +2,7 @@
 // Run the generator to refresh.
 
 /** Result of query `GetArticle`. */
-interface IGetArticleResult {
+export interface IGetArticleResult {
     id: string;
     /** Case-insensitive URL slug. */
     slug: string;
@@ -12,7 +12,7 @@ interface IGetArticleResult {
 }
 
 /** Result of query `ListArticlesWithAuthor`. */
-interface IListArticlesWithAuthorResult {
+export interface IListArticlesWithAuthorResult {
     id: string;
     title: string;
     /** Case-insensitive contact address. */

--- a/packages/bun-sqlgen-core/src/emit/declarations.ts
+++ b/packages/bun-sqlgen-core/src/emit/declarations.ts
@@ -25,12 +25,14 @@ function fieldSignature(field: ResolvedField): ts.PropertySignature {
   return sig;
 }
 
-// The row interface backing one registry entry. Module-local (not exported): the
-// public way to name a row type is `QueryResults['Name']`, so there is a single
-// access path and no second importable surface to keep in sync.
+// The row interface backing one registry entry. Exported so the row type stays
+// nameable when a consumer re-emits it in a `.d.ts` (declaration emission or
+// bundling) — TypeScript dereferences `QueryResults['Name']` to this interface and
+// errors (TS4053) if it can't name it. `QueryResults['Name']` is still the intended
+// access path; the export just keeps the underlying name reachable.
 export function resultInterface(q: EmitModel): ts.InterfaceDeclaration {
   const node = f.createInterfaceDeclaration(
-    undefined,
+    [f.createModifier(ts.SyntaxKind.ExportKeyword)],
     resultName(q.name),
     undefined,
     undefined,

--- a/packages/bun-sqlgen-core/src/generate.ts
+++ b/packages/bun-sqlgen-core/src/generate.ts
@@ -86,7 +86,10 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
       matched.add(f);
     }
   }
-  const sourceFiles = [...matched].filter((f) => f !== outPath && !isGenerated(f));
+  // Sort so the discovery — and therefore the emitted registry order — is stable
+  // across platforms; Bun.Glob yields filesystem order, which differs (macOS vs
+  // Linux CI), making the committed output churn and `--check` fail spuriously.
+  const sourceFiles = [...matched].filter((f) => f !== outPath && !isGenerated(f)).sort();
 
   // Explicit `--dialect` wins over config; default Postgres. Extensions are a
   // PGlite (Postgres) concept; a SQLite config carries none.


### PR DESCRIPTION
Two fixes that make the generated module stable across machines and usable from another package's declaration output. Both surfaced while trialing the package in a real Bun workspace.

## 1. Deterministic output ordering

`generate.ts` collected query files via `Bun.Glob(...).scanSync(...)`, which yields filesystem order — that differs between macOS and Linux. Because the registry is emitted in discovery order, the generated module's ordering changed across platforms, so a file generated on macOS and committed would read as **stale** when `--check` re-generated it on Linux CI (and vice-versa). Migrations were already `.sort()`ed; query files now are too.

## 2. Export the generated result interfaces (TS4053)

The `I<Name>Result` interfaces were module-local, on the assumption that `QueryResults['Name']` is the only access path. That holds for `--noEmit` type-checking, but breaks under **declaration emission**: when a consumer re-emits a row type into a `.d.ts` (e.g. bundling a service whose public method returns `QueryResults['FindPeopleByIds']`), TypeScript dereferences the indexed access to the concrete interface and fails with `TS4053` ("cannot be named") because it isn't exported. Exporting them keeps the underlying name reachable; `QueryResults['Name']` remains the intended handle.

## Validation

Adopted the package across a 5-workspace Bun monorepo (repositories typed from `QueryResults`, the row types flowing through an Elysia Eden `App` type into other packages and a bundled client). Before: CI's codegen check failed on (1) and a `.d.ts` bundle step failed on (2). After: type-check, codegen `--check`, and tests pass on all workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)