### PR TITLE
build!: bump TypeScript to v7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,26 +61,26 @@
         "@electric-sql/pglite": "catalog:",
         "@parshjs/core": "^0.0.10",
         "@repo/bun-sqlgen-core": "workspace:*",
+        "@typescript/typescript6": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
         "@parshjs/codegen": "^0.0.5",
         "@repo/pack-utils": "workspace:*",
         "@repo/typescript-config": "workspace:*",
-      },
-      "peerDependencies": {
-        "typescript": "catalog:",
+        "@types/bun": "catalog:",
       },
     },
     "packages/bun-sqlgen-core": {
       "name": "@repo/bun-sqlgen-core",
       "dependencies": {
         "@electric-sql/pglite": "catalog:",
-        "typescript": "catalog:",
+        "@typescript/typescript6": "catalog:",
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
         "@types/bun": "catalog:",
+        "typescript": "catalog:",
       },
     },
     "packages/internal-scripts": {
@@ -96,6 +96,7 @@
       "name": "@repo/pack-utils",
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
+        "@types/bun": "catalog:",
         "typescript": "catalog:",
       },
     },
@@ -106,7 +107,8 @@
   "catalog": {
     "@electric-sql/pglite": "^0.5.3",
     "@types/bun": "^1.3.14",
-    "typescript": "^5.9.3",
+    "@typescript/typescript6": "^6.0.2",
+    "typescript": "^7.0.2",
     "zod": "^4.4.3",
   },
   "packages": {
@@ -215,6 +217,50 @@
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+
+    "@typescript/old": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@typescript/typescript6": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -358,7 +404,7 @@
 
     "turbo": ["turbo@2.10.0", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.0", "@turbo/darwin-arm64": "2.10.0", "@turbo/linux-64": "2.10.0", "@turbo/linux-arm64": "2.10.0", "@turbo/windows-64": "2.10.0", "@turbo/windows-arm64": "2.10.0" }, "bin": { "turbo": "bin/turbo" } }, "sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -377,6 +423,8 @@
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@parshjs/codegen/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "catalog": {
       "@electric-sql/pglite": "^0.5.3",
       "@types/bun": "^1.3.14",
-      "typescript": "^5.9.3",
+      "@typescript/typescript6": "^6.0.2",
+      "typescript": "^7.0.2",
       "zod": "^4.4.3"
     }
   },

--- a/packages/bun-sqlgen-core/package.json
+++ b/packages/bun-sqlgen-core/package.json
@@ -13,10 +13,11 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "catalog:",
-    "typescript": "catalog:"
+    "@typescript/typescript6": "catalog:"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/packages/bun-sqlgen-core/src/discover.ts
+++ b/packages/bun-sqlgen-core/src/discover.ts
@@ -1,5 +1,5 @@
+import ts from '@typescript/typescript6';
 import type { ReservedSQL, SavepointSQL, SQL, TransactionSQL } from 'bun';
-import ts from 'typescript';
 import type { Dialect, DiscoveredQuery, WritableColumns } from '#types.ts';
 
 // Positional bind placeholder for the dialect: Postgres `$n`, SQLite `?n`. Both

--- a/packages/bun-sqlgen-core/src/emit/ast.ts
+++ b/packages/bun-sqlgen-core/src/emit/ast.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 
 // Shared factory + printer. Everything in the generated module is built as AST and
 // run through one printer, so output is valid by construction (escaping, quoting,

--- a/packages/bun-sqlgen-core/src/emit/declarations.ts
+++ b/packages/bun-sqlgen-core/src/emit/declarations.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from '@typescript/typescript6';
 import { f, propertyName, resultName, typeNode } from '#emit/ast.ts';
 import type { EmitModel, ResolvedField } from '#types.ts';
 

--- a/packages/bun-sqlgen-core/src/emit/index.ts
+++ b/packages/bun-sqlgen-core/src/emit/index.ts
@@ -1,4 +1,4 @@
-import type ts from 'typescript';
+import type ts from '@typescript/typescript6';
 import { printNode } from '#emit/ast.ts';
 import { augmentation, registryInterface, resultInterface } from '#emit/declarations.ts';
 import type { EmitModel } from '#types.ts';

--- a/packages/bun-sqlgen/build.ts
+++ b/packages/bun-sqlgen/build.ts
@@ -19,9 +19,8 @@ const LICENSE_DESTINATION_PATH = join(PKG_DIR, 'LICENSE');
 // Types are explicit to make sure the we pick existing dependencies
 const RUNTIME_DEPENDENCIES: Extract<
   keyof typeof packageJson.dependencies,
-  '@electric-sql/pglite'
->[] = ['@electric-sql/pglite'];
-const PEER_DEPENDENCIES = Object.keys(packageJson.peerDependencies);
+  '@electric-sql/pglite' | '@typescript/typescript6'
+>[] = ['@electric-sql/pglite', '@typescript/typescript6'];
 
 // Regenerate the parsh command tree first so the bundle can never embed a stale
 // one. Reuses the `codegen` script so the args stay single-sourced.
@@ -37,7 +36,7 @@ const cliBuildResult = await Bun.build({
   root: SRC_DIR,
   outdir: DIST_DIR,
   target: 'bun',
-  external: [...RUNTIME_DEPENDENCIES, ...PEER_DEPENDENCIES],
+  external: [...RUNTIME_DEPENDENCIES],
 });
 assertBuildSuccess({ buildResult: cliBuildResult });
 printBuildOutput({ buildResult: cliBuildResult });
@@ -55,7 +54,6 @@ await setPackageJsonDependencies({
   sourcePackageJsonPath: internalPackageJsonPath,
   targetPackageJsonPath: publicPackageJsonPath,
   dependencies: RUNTIME_DEPENDENCIES,
-  peerDependencies: PEER_DEPENDENCIES,
 });
 
 console.log('✅ Done');

--- a/packages/bun-sqlgen/package.json
+++ b/packages/bun-sqlgen/package.json
@@ -29,14 +29,13 @@
     "@electric-sql/pglite": "catalog:",
     "@parshjs/core": "^0.0.10",
     "@repo/bun-sqlgen-core": "workspace:*",
+    "@typescript/typescript6": "catalog:",
     "zod": "catalog:"
-  },
-  "peerDependencies": {
-    "typescript": "catalog:"
   },
   "devDependencies": {
     "@parshjs/codegen": "^0.0.5",
     "@repo/pack-utils": "workspace:*",
-    "@repo/typescript-config": "workspace:*"
+    "@repo/typescript-config": "workspace:*",
+    "@types/bun": "catalog:"
   }
 }

--- a/packages/bun-sqlgen/pkg/package.json
+++ b/packages/bun-sqlgen/pkg/package.json
@@ -35,9 +35,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@electric-sql/pglite": "^0.5.2"
-  },
-  "peerDependencies": {
-    "typescript": "^5.9.3"
+    "@electric-sql/pglite": "^0.5.3",
+    "@typescript/typescript6": "^6.0.2"
   }
 }

--- a/packages/pack-utils/package.json
+++ b/packages/pack-utils/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
+    "@types/bun": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["ESNext"],
+    "types": ["bun"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
TypeScript 7 is the native (Go) compiler and no longer ships the JS compiler API that `bun-sqlgen-core` builds on (`ts.factory`, printer, program, checker). This bumps the toolchain to TS 7 for type-checking and sources the compiler API from the side-by-side [`@typescript/typescript6`](https://www.npmjs.com/package/@typescript/typescript6) package.

- `typescript` → `^7.0.2`; add `@typescript/typescript6` `^6.0.2` for the compiler API (imported by `bun-sqlgen-core`)
- `@typescript/typescript6` ships as a **normal dependency** of `@ilbertt/bun-sqlgen` (previously `typescript` was a peer dep) — decoupled from the consumer's TS version
- base tsconfig now sets `types: ["bun"]` — TS 7 no longer auto-discovers ambient `@types`; declared `@types/bun` where it was implicit

**BREAKING CHANGE:** drops the `typescript` peer dependency; the published package now targets the TypeScript 7 toolchain.

Verified `bun check:all` (8/8, including the examples' codegen `--check`) and `bun run build` (including native TS 7 declaration emit) pass — generated output is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
