### PR TITLE
build: bump pglite to 0.5.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,7 +105,7 @@
     },
   },
   "catalog": {
-    "@electric-sql/pglite": "^0.5.4",
+    "@electric-sql/pglite": "^0.5.5",
     "@types/bun": "^1.3.14",
     "@typescript/typescript6": "^6.0.2",
     "typescript": "^7.0.2",
@@ -172,7 +172,7 @@
 
     "@conventional-changelog/template": ["@conventional-changelog/template@1.2.1", "", {}, "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w=="],
 
-    "@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.5.5", "", {}, "sha512-QeZ+oB7QaU4EJj2awrB8hwFZ5TXxLRBQ9Gfq0dQauYDdWsRtuWRCERgtri35vRfL07KQHlVlc/4Qxvn7a5AXeA=="],
 
     "@parshjs/codegen": ["@parshjs/codegen@0.0.5", "", { "dependencies": { "typescript": "^5.9.3" }, "bin": { "parsh-codegen": "dist/cli/main.js" } }, "sha512-fJFVIa5A6OWiABD8kZqSm2A75SV+ZgDuakQ/XASmYpJyd/FN6E/2erkev2LdqiFD6WySnbux8O/Dh+ms4oNzlw=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "examples/*"
     ],
     "catalog": {
-      "@electric-sql/pglite": "^0.5.4",
+      "@electric-sql/pglite": "^0.5.5",
       "@types/bun": "^1.3.14",
       "@typescript/typescript6": "^6.0.2",
       "typescript": "^7.0.2",

--- a/packages/bun-sqlgen/pkg/package.json
+++ b/packages/bun-sqlgen/pkg/package.json
@@ -35,7 +35,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@electric-sql/pglite": "^0.5.3",
+    "@electric-sql/pglite": "^0.5.5",
     "@typescript/typescript6": "^6.0.2"
   }
 }


### PR DESCRIPTION
Two separate drifts, one fix.

The catalog was a minor behind (`^0.5.4`, latest is `0.5.5`), and `packages/bun-sqlgen/pkg/package.json` was stale against the catalog on top of that — it still pinned `^0.5.3`. Since `build.ts` resolves `catalog:` and writes the published manifest, **every `bun run build` rewrote that file and left the working tree dirty**. Bumping the catalog and committing the regenerated manifest makes the build idempotent again:

```
before=6b8e371f8a6ad7eeaeb66711646d3c54 after=6b8e371f8a6ad7eeaeb66711646d3c54
```

### Introspection is unaffected

The risk with a PGlite bump here is that the embedded Postgres changes and the generator starts emitting different types. It doesn't:

- 0.5.4 and 0.5.5 are both `PostgreSQL 18.3`.
- All three examples regenerate **byte-identically** — zero diff in `queries.gen.ts`.

### Note

CI runs `bun run build` but never checks the tree for dirtiness afterwards, which is why this drifted silently in the first place. A `git diff --exit-code` after the build step would stop it recurring — happy to add that separately if you want it.