### PR TITLE
feat: check that migrations are ordered

### DIFF
--- a/packages/bun-sqlgen-core/src/generate.ts
+++ b/packages/bun-sqlgen-core/src/generate.ts
@@ -42,12 +42,12 @@ export interface GenerateOptions {
   /**
    * Fail unless every migration filename carries a unique sequence prefix, all of one
    * width — what makes filename order (the order they apply in) the intended one.
-   * Merged over config rather than replacing it, so turning the check on from the CLI
-   * keeps the `prefixPattern` the config set. Off unless enabled. Unlike the other
-   * checks it guards generation itself, so it runs in every mode rather than
-   * replacing the write.
+   * Partial because `--check-migration-order` contributes only `enabled`: this is
+   * merged over the config's settings, and the result still needs a `prefixPattern`.
+   * Off unless enabled. Unlike the other checks it guards generation itself, so it
+   * runs in every mode rather than replacing the write.
    */
-  checkMigrationOrder?: MigrationOrderCheck;
+  checkMigrationOrder?: Partial<MigrationOrderCheck>;
   /** Explicit path to `sqlgen.config.{ts,js,mjs}`; auto-discovered otherwise. */
   configPath?: string;
   /** Output path for the aggregated module, relative to `cwd`. Defaults to `src/queries.gen.ts`. */
@@ -70,10 +70,11 @@ export interface MigrationOrderCheck {
   enabled: boolean;
   /**
    * What identifies a filename's sequence prefix — the part that has to be unique and
-   * equally wide across every migration. Defaults to a leading run of digits (`/^\d+/`);
-   * `/^\d{14}_/` covers a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
+   * equally wide across every migration. Required, and deliberately not defaulted: only
+   * you know which convention your migrations were named for. `/^\d+/` matches
+   * `0001_init.sql`, `/^\d{14}_/` a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
    */
-  prefixPattern?: RegExp;
+  prefixPattern: RegExp;
 }
 
 export interface GenerateFailure {
@@ -117,6 +118,13 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
   // pattern the config chose for it.
   const orderCheck = { ...config.checkMigrationOrder, ...options.checkMigrationOrder };
   if (orderCheck.enabled) {
+    // The config is imported at runtime, so its own type can't be the guarantee here.
+    if (!orderCheck.prefixPattern) {
+      throw new Error(
+        'checkMigrationOrder is enabled but names no prefixPattern — set one in ' +
+          'sqlgen.config.ts (`prefixPattern: /^\\d+/` for 0001_init.sql).',
+      );
+    }
     requireOrderedMigrations({ migrationsDir, prefixPattern: orderCheck.prefixPattern });
   }
 

--- a/packages/bun-sqlgen-core/src/generate.ts
+++ b/packages/bun-sqlgen-core/src/generate.ts
@@ -42,11 +42,12 @@ export interface GenerateOptions {
   /**
    * Fail unless every migration filename carries a unique sequence prefix, all of one
    * width — what makes filename order (the order they apply in) the intended one.
-   * `true` expects a numeric prefix; a `RegExp` says where the prefix ends instead.
-   * Overrides config; defaults to `false`. Unlike the other checks it guards generation
-   * itself, so it runs in every mode rather than replacing the write.
+   * Merged over config rather than replacing it, so turning the check on from the CLI
+   * keeps the `prefixPattern` the config set. Off unless enabled. Unlike the other
+   * checks it guards generation itself, so it runs in every mode rather than
+   * replacing the write.
    */
-  checkMigrationOrder?: boolean | RegExp;
+  checkMigrationOrder?: MigrationOrderCheck;
   /** Explicit path to `sqlgen.config.{ts,js,mjs}`; auto-discovered otherwise. */
   configPath?: string;
   /** Output path for the aggregated module, relative to `cwd`. Defaults to `src/queries.gen.ts`. */
@@ -62,6 +63,17 @@ export interface GenerateOptions {
    * constraint names. Overrides config; defaults to `true`.
    */
   schema?: boolean;
+}
+
+/** Settings for the migration-order check. */
+export interface MigrationOrderCheck {
+  enabled: boolean;
+  /**
+   * What identifies a filename's sequence prefix — the part that has to be unique and
+   * equally wide across every migration. Defaults to a leading run of digits (`/^\d+/`);
+   * `/^\d{14}_/` covers a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
+   */
+  prefixPattern?: RegExp;
 }
 
 export interface GenerateFailure {
@@ -100,10 +112,12 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
   const migrationsDir = resolve(cwd, options.migrations);
   const outPath = resolve(cwd, options.out ?? DEFAULT_OUT);
 
-  // Before anything expensive: a misordered set builds the wrong schema silently.
-  const checkOrder = options.checkMigrationOrder ?? config.checkMigrationOrder ?? false;
-  if (checkOrder) {
-    requireOrderedMigrations({ migrationsDir, pattern: checkOrder });
+  // Before anything expensive: a misordered set builds the wrong schema silently. The
+  // merge lets `--check-migration-order` enable the check without discarding the
+  // pattern the config chose for it.
+  const orderCheck = { ...config.checkMigrationOrder, ...options.checkMigrationOrder };
+  if (orderCheck.enabled) {
+    requireOrderedMigrations({ migrationsDir, prefixPattern: orderCheck.prefixPattern });
   }
 
   // Resolve the query globs; skip our own generated output.

--- a/packages/bun-sqlgen-core/src/generate.ts
+++ b/packages/bun-sqlgen-core/src/generate.ts
@@ -40,11 +40,13 @@ export interface GenerateOptions {
   /** Fail if the committed generated module is out of date. Read-only (no write). */
   checkStale?: boolean;
   /**
-   * Fail unless every migration filename carries a unique, consistently zero-padded
-   * sequence number. Overrides config; defaults to `false`. Unlike the other checks it
-   * guards generation itself, so it runs in every mode rather than replacing the write.
+   * Fail unless every migration filename carries a unique sequence prefix, all of one
+   * width — what makes filename order (the order they apply in) the intended one.
+   * `true` expects a numeric prefix; a `RegExp` says where the prefix ends instead.
+   * Overrides config; defaults to `false`. Unlike the other checks it guards generation
+   * itself, so it runs in every mode rather than replacing the write.
    */
-  checkMigrationOrder?: boolean;
+  checkMigrationOrder?: boolean | RegExp;
   /** Explicit path to `sqlgen.config.{ts,js,mjs}`; auto-discovered otherwise. */
   configPath?: string;
   /** Output path for the aggregated module, relative to `cwd`. Defaults to `src/queries.gen.ts`. */
@@ -99,8 +101,9 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
   const outPath = resolve(cwd, options.out ?? DEFAULT_OUT);
 
   // Before anything expensive: a misordered set builds the wrong schema silently.
-  if (options.checkMigrationOrder ?? config.checkMigrationOrder ?? false) {
-    requireOrderedMigrations(migrationsDir);
+  const checkOrder = options.checkMigrationOrder ?? config.checkMigrationOrder ?? false;
+  if (checkOrder) {
+    requireOrderedMigrations({ migrationsDir, pattern: checkOrder });
   }
 
   // Resolve the query globs; skip our own generated output.

--- a/packages/bun-sqlgen-core/src/generate.ts
+++ b/packages/bun-sqlgen-core/src/generate.ts
@@ -42,12 +42,11 @@ export interface GenerateOptions {
   /**
    * Fail unless every migration filename carries a unique sequence prefix, all of one
    * width — what makes filename order (the order they apply in) the intended one.
-   * Partial because `--check-migration-order` contributes only `enabled`: this is
-   * merged over the config's settings, and the result still needs a `prefixPattern`.
-   * Off unless enabled. Unlike the other checks it guards generation itself, so it
-   * runs in every mode rather than replacing the write.
+   * Overrides config; absent from both, the check doesn't run. Unlike the other checks
+   * it guards generation itself, so it runs in every mode rather than replacing the
+   * write.
    */
-  checkMigrationOrder?: Partial<MigrationOrderCheck>;
+  checkMigrationOrder?: MigrationOrderCheck;
   /** Explicit path to `sqlgen.config.{ts,js,mjs}`; auto-discovered otherwise. */
   configPath?: string;
   /** Output path for the aggregated module, relative to `cwd`. Defaults to `src/queries.gen.ts`. */
@@ -65,14 +64,13 @@ export interface GenerateOptions {
   schema?: boolean;
 }
 
-/** Settings for the migration-order check. */
+/** Settings for the migration-order check; its presence is what turns the check on. */
 export interface MigrationOrderCheck {
-  enabled: boolean;
   /**
    * What identifies a filename's sequence prefix — the part that has to be unique and
-   * equally wide across every migration. Required, and deliberately not defaulted: only
-   * you know which convention your migrations were named for. `/^\d+/` matches
-   * `0001_init.sql`, `/^\d{14}_/` a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
+   * equally wide across every migration. Not defaulted: only you know which convention
+   * your filenames were named for. `/^\d+/` matches `0001_init.sql`, `/^\d{14}_/` a
+   * timestamp scheme, `/^[a-z]{4}_/` a lettered one.
    */
   prefixPattern: RegExp;
 }
@@ -113,18 +111,9 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
   const migrationsDir = resolve(cwd, options.migrations);
   const outPath = resolve(cwd, options.out ?? DEFAULT_OUT);
 
-  // Before anything expensive: a misordered set builds the wrong schema silently. The
-  // merge lets `--check-migration-order` enable the check without discarding the
-  // pattern the config chose for it.
-  const orderCheck = { ...config.checkMigrationOrder, ...options.checkMigrationOrder };
-  if (orderCheck.enabled) {
-    // The config is imported at runtime, so its own type can't be the guarantee here.
-    if (!orderCheck.prefixPattern) {
-      throw new Error(
-        'checkMigrationOrder is enabled but names no prefixPattern — set one in ' +
-          'sqlgen.config.ts (`prefixPattern: /^\\d+/` for 0001_init.sql).',
-      );
-    }
+  // Before anything expensive: a misordered set builds the wrong schema silently.
+  const orderCheck = options.checkMigrationOrder ?? config.checkMigrationOrder;
+  if (orderCheck) {
     requireOrderedMigrations({ migrationsDir, prefixPattern: orderCheck.prefixPattern });
   }
 

--- a/packages/bun-sqlgen-core/src/generate.ts
+++ b/packages/bun-sqlgen-core/src/generate.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { createDiscoverer } from '#discover.ts';
 import { emitModule, GENERATED_MARKER } from '#emit/index.ts';
 import { createIntrospector } from '#introspect/index.ts';
+import { requireOrderedMigrations } from '#introspect/migrations.ts';
 import {
   parseColumnComments,
   parseOverrides,
@@ -19,7 +20,7 @@ import type {
 } from '#types.ts';
 
 type LoadedConfig = Partial<Omit<IntrospectorOptions, 'migrationsDir'>> &
-  Pick<GenerateOptions, 'schema'>;
+  Pick<GenerateOptions, 'schema' | 'checkMigrationOrder'>;
 
 // Where the aggregated module lands when `--out` is omitted. A `.ts`, not a `.d.ts`:
 // the module is a normal source file, so it can carry values as well as types.
@@ -38,6 +39,12 @@ export interface GenerateOptions {
   checkQueries?: boolean;
   /** Fail if the committed generated module is out of date. Read-only (no write). */
   checkStale?: boolean;
+  /**
+   * Fail unless every migration filename carries a unique, consistently zero-padded
+   * sequence number. Overrides config; defaults to `false`. Unlike the other checks it
+   * guards generation itself, so it runs in every mode rather than replacing the write.
+   */
+  checkMigrationOrder?: boolean;
   /** Explicit path to `sqlgen.config.{ts,js,mjs}`; auto-discovered otherwise. */
   configPath?: string;
   /** Output path for the aggregated module, relative to `cwd`. Defaults to `src/queries.gen.ts`. */
@@ -90,6 +97,11 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
 
   const migrationsDir = resolve(cwd, options.migrations);
   const outPath = resolve(cwd, options.out ?? DEFAULT_OUT);
+
+  // Before anything expensive: a misordered set builds the wrong schema silently.
+  if (options.checkMigrationOrder ?? config.checkMigrationOrder ?? false) {
+    requireOrderedMigrations(migrationsDir);
+  }
 
   // Resolve the query globs; skip our own generated output.
   const globs = Array.isArray(options.queries) ? options.queries : [options.queries];

--- a/packages/bun-sqlgen-core/src/index.ts
+++ b/packages/bun-sqlgen-core/src/index.ts
@@ -4,6 +4,7 @@ export type {
   GenerateFailure,
   GenerateOptions,
   GenerateResult,
+  MigrationOrderCheck,
 } from '#generate.ts';
 export { generate } from '#generate.ts';
 export { oidToTs, PG_OID } from '#oids.ts';

--- a/packages/bun-sqlgen-core/src/introspect/migrations.ts
+++ b/packages/bun-sqlgen-core/src/introspect/migrations.ts
@@ -32,23 +32,21 @@ export async function applyMigrations(input: {
   }
 }
 
-/** Identifies the sequence prefix when the check names no pattern of its own. */
-const DEFAULT_PREFIX_PATTERN = /^\d+/;
-
 /**
  * Migrations apply in filename order, so that is the order you meant only while every
  * filename carries a sequence prefix, all of them the same width and none repeated:
  * `1, 2, 10` applies as `1, 10, 2`. Width, not "is it a number", is the invariant —
  * equal-width prefixes sort the same way in any positional scheme, so a letter or
- * timestamp convention passes on its own terms. `pattern` says where the prefix ends.
+ * timestamp convention passes on its own terms. `prefixPattern` says where the prefix
+ * ends; there is no default, since only the caller knows the convention it meant.
  */
 export function requireOrderedMigrations(input: {
   migrationsDir: string;
-  prefixPattern?: RegExp;
+  prefixPattern: RegExp;
 }): void {
-  const configured = input.prefixPattern ?? DEFAULT_PREFIX_PATTERN;
   // `exec` carries `lastIndex` between calls under `g`/`y`; each filename is its own test.
-  const pattern = new RegExp(configured.source, configured.flags.replace(/[gy]/g, ''));
+  const { prefixPattern } = input;
+  const pattern = new RegExp(prefixPattern.source, prefixPattern.flags.replace(/[gy]/g, ''));
 
   const problems: string[] = [];
   const prefixes: Array<{ filename: string; prefix: string }> = [];

--- a/packages/bun-sqlgen-core/src/introspect/migrations.ts
+++ b/packages/bun-sqlgen-core/src/introspect/migrations.ts
@@ -1,6 +1,13 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+/** The `*.sql` files in `migrationsDir`, in the order they are applied. */
+function listMigrations(migrationsDir: string): string[] {
+  return readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+}
+
 /**
  * Apply every `*.sql` migration in filename order to the throwaway DB, optionally
  * rewriting each via `transformMigration`. `exec` is the engine's multi-statement
@@ -12,10 +19,7 @@ export async function applyMigrations(input: {
   transformMigration?: (input: { sql: string; filename: string }) => string;
 }): Promise<void> {
   const { migrationsDir, exec, transformMigration } = input;
-  const files = readdirSync(migrationsDir)
-    .filter((f) => f.endsWith('.sql'))
-    .sort();
-  for (const filename of files) {
+  for (const filename of listMigrations(migrationsDir)) {
     try {
       let sql = readFileSync(join(migrationsDir, filename), 'utf8');
       if (transformMigration) {
@@ -25,6 +29,59 @@ export async function applyMigrations(input: {
     } catch (e) {
       throw new Error(`migration ${filename} failed to apply: ${firstLine(e)}`);
     }
+  }
+}
+
+const SEQUENCE_PREFIX = /^\d+/;
+
+/**
+ * Migrations apply in filename order, which agrees with the order their numbers imply
+ * only while every prefix is padded to the same width: `1, 2, 10` applies as
+ * `1, 10, 2`, building a different schema than production without failing. Opt-in via
+ * `checkMigrationOrder`, since an unnumbered scheme is a valid choice on its own.
+ */
+export function requireOrderedMigrations(migrationsDir: string): void {
+  const problems: string[] = [];
+  const numbered: Array<{ filename: string; sequence: number }> = [];
+
+  for (const filename of listMigrations(migrationsDir)) {
+    const prefix = SEQUENCE_PREFIX.exec(filename)?.[0];
+    if (prefix === undefined) {
+      problems.push(`${filename} — no leading sequence number`);
+      continue;
+    }
+    numbered.push({ filename, sequence: Number(prefix) });
+  }
+
+  // Two migrations claiming the same number — the usual merge accident — leave the
+  // order between them to the rest of the filename.
+  const bySequence = new Map<number, string>();
+  for (const { filename, sequence } of numbered) {
+    const claimed = bySequence.get(sequence);
+    if (claimed === undefined) {
+      bySequence.set(sequence, filename);
+    } else {
+      problems.push(`${filename} — same sequence number as ${claimed}`);
+    }
+  }
+
+  // The list is already in applied order, so "ascending across every adjacent pair"
+  // is exactly "filename order == numeric order".
+  let previous: { filename: string; sequence: number } | null = null;
+  for (const entry of numbered) {
+    if (previous && previous.sequence > entry.sequence) {
+      problems.push(
+        `${previous.filename} — applies before ${entry.filename}, but ${previous.sequence} > ${entry.sequence}`,
+      );
+    }
+    previous = entry;
+  }
+
+  if (problems.length) {
+    throw new Error(
+      `migrations are not in sequence order:\n${problems.map((p) => `  ✗ ${p}`).join('\n')}\n` +
+        '  Migrations apply in filename order — zero-pad the prefixes (0001, 0002, … 0010) so it matches.',
+    );
   }
 }
 

--- a/packages/bun-sqlgen-core/src/introspect/migrations.ts
+++ b/packages/bun-sqlgen-core/src/introspect/migrations.ts
@@ -32,55 +32,61 @@ export async function applyMigrations(input: {
   }
 }
 
-const SEQUENCE_PREFIX = /^\d+/;
+/** Identifies the sequence prefix when the check is turned on with a plain `true`. */
+const DEFAULT_SEQUENCE_PREFIX = /^\d+/;
 
 /**
- * Migrations apply in filename order, which agrees with the order their numbers imply
- * only while every prefix is padded to the same width: `1, 2, 10` applies as
- * `1, 10, 2`, building a different schema than production without failing. Opt-in via
- * `checkMigrationOrder`, since an unnumbered scheme is a valid choice on its own.
+ * Migrations apply in filename order, so that is the order you meant only while every
+ * filename carries a sequence prefix, all of them the same width and none repeated:
+ * `1, 2, 10` applies as `1, 10, 2`. Width, not "is it a number", is the invariant —
+ * equal-width prefixes sort the same way in any positional scheme, so a letter or
+ * timestamp convention passes on its own terms. `pattern` says where the prefix ends.
  */
-export function requireOrderedMigrations(migrationsDir: string): void {
-  const problems: string[] = [];
-  const numbered: Array<{ filename: string; sequence: number }> = [];
+export function requireOrderedMigrations(input: {
+  migrationsDir: string;
+  pattern: true | RegExp;
+}): void {
+  const configured = input.pattern === true ? DEFAULT_SEQUENCE_PREFIX : input.pattern;
+  // `exec` carries `lastIndex` between calls under `g`/`y`; each filename is its own test.
+  const pattern = new RegExp(configured.source, configured.flags.replace(/[gy]/g, ''));
 
-  for (const filename of listMigrations(migrationsDir)) {
-    const prefix = SEQUENCE_PREFIX.exec(filename)?.[0];
-    if (prefix === undefined) {
-      problems.push(`${filename} — no leading sequence number`);
+  const problems: string[] = [];
+  const prefixes: Array<{ filename: string; prefix: string }> = [];
+
+  for (const filename of listMigrations(input.migrationsDir)) {
+    const match = pattern.exec(filename);
+    // A match anywhere but the start orders nothing.
+    const prefix = match?.index === 0 ? match[0] : null;
+    if (prefix === null) {
+      problems.push(`${filename} — no ${pattern} prefix`);
       continue;
     }
-    numbered.push({ filename, sequence: Number(prefix) });
+    prefixes.push({ filename, prefix });
   }
 
-  // Two migrations claiming the same number — the usual merge accident — leave the
-  // order between them to the rest of the filename.
-  const bySequence = new Map<number, string>();
-  for (const { filename, sequence } of numbered) {
-    const claimed = bySequence.get(sequence);
+  // Two migrations claiming one prefix — the usual merge accident — leave the order
+  // between them to whatever the rest of the filename happens to be.
+  const claimedBy = new Map<string, string>();
+  for (const { filename, prefix } of prefixes) {
+    const claimed = claimedBy.get(prefix);
     if (claimed === undefined) {
-      bySequence.set(sequence, filename);
+      claimedBy.set(prefix, filename);
     } else {
-      problems.push(`${filename} — same sequence number as ${claimed}`);
+      problems.push(`${filename} — same "${prefix}" prefix as ${claimed}`);
     }
   }
 
-  // The list is already in applied order, so "ascending across every adjacent pair"
-  // is exactly "filename order == numeric order".
-  let previous: { filename: string; sequence: number } | null = null;
-  for (const entry of numbered) {
-    if (previous && previous.sequence > entry.sequence) {
-      problems.push(
-        `${previous.filename} — applies before ${entry.filename}, but ${previous.sequence} > ${entry.sequence}`,
-      );
+  const widest = Math.max(0, ...prefixes.map((p) => p.prefix.length));
+  for (const { filename, prefix } of prefixes) {
+    if (prefix.length < widest) {
+      problems.push(`${filename} — "${prefix}" is ${prefix.length} wide, the widest is ${widest}`);
     }
-    previous = entry;
   }
 
   if (problems.length) {
     throw new Error(
-      `migrations are not in sequence order:\n${problems.map((p) => `  ✗ ${p}`).join('\n')}\n` +
-        '  Migrations apply in filename order — zero-pad the prefixes (0001, 0002, … 0010) so it matches.',
+      `migrations are not in a dependable order:\n${problems.map((p) => `  ✗ ${p}`).join('\n')}\n` +
+        `  They apply in filename order — give each a unique ${pattern} prefix, padded to one width.`,
     );
   }
 }

--- a/packages/bun-sqlgen-core/src/introspect/migrations.ts
+++ b/packages/bun-sqlgen-core/src/introspect/migrations.ts
@@ -32,8 +32,8 @@ export async function applyMigrations(input: {
   }
 }
 
-/** Identifies the sequence prefix when the check is turned on with a plain `true`. */
-const DEFAULT_SEQUENCE_PREFIX = /^\d+/;
+/** Identifies the sequence prefix when the check names no pattern of its own. */
+const DEFAULT_PREFIX_PATTERN = /^\d+/;
 
 /**
  * Migrations apply in filename order, so that is the order you meant only while every
@@ -44,9 +44,9 @@ const DEFAULT_SEQUENCE_PREFIX = /^\d+/;
  */
 export function requireOrderedMigrations(input: {
   migrationsDir: string;
-  pattern: true | RegExp;
+  prefixPattern?: RegExp;
 }): void {
-  const configured = input.pattern === true ? DEFAULT_SEQUENCE_PREFIX : input.pattern;
+  const configured = input.prefixPattern ?? DEFAULT_PREFIX_PATTERN;
   // `exec` carries `lastIndex` between calls under `g`/`y`; each filename is its own test.
   const pattern = new RegExp(configured.source, configured.flags.replace(/[gy]/g, ''));
 

--- a/packages/bun-sqlgen/pkg/README.md
+++ b/packages/bun-sqlgen/pkg/README.md
@@ -150,12 +150,26 @@ than the output, so it runs on a plain generate too and is *not* folded into `--
 bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order
 ```
 
-Migrations apply in filename order, which only matches the order their numbers imply
-while every prefix is padded to the same width — `1, 2, 10` applies as `1, 10, 2`,
-building a schema production never had. The flag fails on a migration with no leading
-sequence number, on two migrations claiming the same number, and on any pair whose
-filename order disagrees with their numbers. Turn it on for the whole project with
-`checkMigrationOrder: true` in `sqlgen.config.ts`.
+Migrations apply in filename order, which is the order you meant only while every
+filename carries a sequence prefix of the same width — `1, 2, 10` applies as
+`1, 10, 2`, building a schema production never had. The flag fails on a migration with
+no prefix, on two claiming the same prefix, and on prefixes of differing widths. Gaps
+are fine.
+
+Width, not "is it a number", is what's checked: equal-width prefixes sort the same way
+in any positional scheme. So if you don't number your migrations, name the scheme
+instead of the default and it's held to its own terms:
+
+```ts
+// sqlgen.config.ts
+export default defineConfig({
+  checkMigrationOrder: /^[a-z]{4}_/, // aaaa_init.sql, aaab_add_users.sql, …
+});
+```
+
+`true` uses the default numeric prefix (`/^\d+/`), which is what the CLI flag turns on;
+`/^\d{14}_/` covers a timestamp convention. The config field applies on a plain
+generate too, so the check holds whether or not CI passed the flag.
 
 Commit the generated file and run `--check` in CI so an edited query can never
 type-check against a stale shape. The
@@ -228,7 +242,8 @@ export default defineConfig({
   // CONCURRENTLY can't run inside the transaction a multi-statement file applies in).
   transformMigration: ({ sql }) => sql.replace(/\bCONCURRENTLY\b/g, ''),
   // require every migration to be numbered 0001, 0002, … so filename order
-  // (the order they apply in) matches the order the numbers imply.
+  // (the order they apply in) is the order they were meant to run in. A RegExp
+  // here replaces the numeric default with your own prefix scheme.
   checkMigrationOrder: true,
 });
 ```

--- a/packages/bun-sqlgen/pkg/README.md
+++ b/packages/bun-sqlgen/pkg/README.md
@@ -143,6 +143,20 @@ non-zero on a problem:
 - **`--check-stale`** — fail if the committed `queries.gen.ts` is out of date.
 - **`--check`** — run both; the one-flag CI default.
 
+A fourth flag, **`--check-migration-order`**, guards the migrations themselves rather
+than the output, so it runs on a plain generate too and is *not* folded into `--check`:
+
+```sh
+bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order
+```
+
+Migrations apply in filename order, which only matches the order their numbers imply
+while every prefix is padded to the same width — `1, 2, 10` applies as `1, 10, 2`,
+building a schema production never had. The flag fails on a migration with no leading
+sequence number, on two migrations claiming the same number, and on any pair whose
+filename order disagrees with their numbers. Turn it on for the whole project with
+`checkMigrationOrder: true` in `sqlgen.config.ts`.
+
 Commit the generated file and run `--check` in CI so an edited query can never
 type-check against a stale shape. The
 [`check-only` example](https://github.com/ilbertt/bun-sqlgen/tree/main/examples/check-only)
@@ -213,13 +227,16 @@ export default defineConfig({
   // rewrite/strip statements PGlite can't run, per migration file (CREATE INDEX
   // CONCURRENTLY can't run inside the transaction a multi-statement file applies in).
   transformMigration: ({ sql }) => sql.replace(/\bCONCURRENTLY\b/g, ''),
+  // require every migration to be numbered 0001, 0002, … so filename order
+  // (the order they apply in) matches the order the numbers imply.
+  checkMigrationOrder: true,
 });
 ```
 
 `defineConfig` is optional — a plain `export default { … }` still works, but you
 lose the type-checking and autocompletion.
 
-A runnable walkthrough of all three fields lives in the
+A runnable walkthrough of the three schema-shaping fields lives in the
 [`with-config` example](https://github.com/ilbertt/bun-sqlgen/tree/main/examples/with-config).
 `extensions` is Postgres-only; `prelude` and `transformMigration` apply to both
 dialects, and `dialect: 'sqlite'` selects SQLite (the `--dialect` flag overrides it).

--- a/packages/bun-sqlgen/pkg/README.md
+++ b/packages/bun-sqlgen/pkg/README.md
@@ -143,37 +143,21 @@ non-zero on a problem:
 - **`--check-stale`** — fail if the committed `queries.gen.ts` is out of date.
 - **`--check`** — run both; the one-flag CI default.
 
-### Migration order
-
-A fourth check guards the migrations themselves rather than the output, so it runs on a
-plain generate too and is *not* folded into `--check`. It needs to know your naming
-convention, so you give it one — either in the config, or as the flag's value:
+A fourth check guards the migrations rather than the output, so it runs on a plain
+generate too and isn't folded into `--check`. Migrations apply in filename order, which
+is the order you meant only while every prefix is the same width — `1, 2, 10` applies
+as `1, 10, 2`. Naming the prefix turns the check on:
 
 ```ts
 // sqlgen.config.ts
 export default defineConfig({
-  checkMigrationOrder: {
-    prefixPattern: /^\d+/, // 0001_init.sql, 0002_add_users.sql, …
-  },
+  checkMigrationOrder: { prefixPattern: /^\d+/ }, // or --check-migration-order '^\d+'
 });
 ```
 
-```sh
-bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order '^\d+'
-```
-
-Naming a pattern is what turns the check on; there is no default, because only you know
-which convention your filenames were named for. The flag overrides the config.
-
-Migrations apply in filename order, which is the order you meant only while every
-filename carries a sequence prefix of the same width — `1, 2, 10` applies as
-`1, 10, 2`, building a schema production never had. The check fails on a migration with
-no prefix, on two claiming the same prefix, and on prefixes of differing widths. Gaps
-are fine.
-
-Width, not "is it a number", is what's checked: equal-width prefixes sort the same way
-in any positional scheme, so a scheme that doesn't number at all is held to its own
-terms — `/^[a-z]{4}_/` for `aaaa_init.sql`, `/^\d{14}_/` for a timestamp convention.
+It fails on a migration with no prefix, on two sharing one, and on prefixes of differing
+widths; gaps are fine. Width is the whole rule, so an unnumbered scheme works on its own
+terms: `/^[a-z]{4}_/`, `/^\d{14}_/`.
 
 Commit the generated file and run `--check` in CI so an edited query can never
 type-check against a stale shape. The
@@ -245,16 +229,13 @@ export default defineConfig({
   // rewrite/strip statements PGlite can't run, per migration file (CREATE INDEX
   // CONCURRENTLY can't run inside the transaction a multi-statement file applies in).
   transformMigration: ({ sql }) => sql.replace(/\bCONCURRENTLY\b/g, ''),
-  // require every migration to be numbered 0001, 0002, … so filename order
-  // (the order they apply in) is the order they were meant to run in.
-  checkMigrationOrder: { prefixPattern: /^\d+/ },
 });
 ```
 
 `defineConfig` is optional — a plain `export default { … }` still works, but you
 lose the type-checking and autocompletion.
 
-A runnable walkthrough of the three schema-shaping fields lives in the
+A runnable walkthrough of all three fields lives in the
 [`with-config` example](https://github.com/ilbertt/bun-sqlgen/tree/main/examples/with-config).
 `extensions` is Postgres-only; `prelude` and `transformMigration` apply to both
 dialects, and `dialect: 'sqlite'` selects SQLite (the `--dialect` flag overrides it).

--- a/packages/bun-sqlgen/pkg/README.md
+++ b/packages/bun-sqlgen/pkg/README.md
@@ -143,37 +143,43 @@ non-zero on a problem:
 - **`--check-stale`** — fail if the committed `queries.gen.ts` is out of date.
 - **`--check`** — run both; the one-flag CI default.
 
-A fourth flag, **`--check-migration-order`**, guards the migrations themselves rather
-than the output, so it runs on a plain generate too and is *not* folded into `--check`:
+### Migration order
 
-```sh
-bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order
-```
-
-Migrations apply in filename order, which is the order you meant only while every
-filename carries a sequence prefix of the same width — `1, 2, 10` applies as
-`1, 10, 2`, building a schema production never had. The flag fails on a migration with
-no prefix, on two claiming the same prefix, and on prefixes of differing widths. Gaps
-are fine.
-
-Width, not "is it a number", is what's checked: equal-width prefixes sort the same way
-in any positional scheme. So if you don't number your migrations, name the scheme
-instead of the default and it's held to its own terms:
+A fourth check guards the migrations themselves rather than the output, so it runs on a
+plain generate too and is *not* folded into `--check`. It's configured, not flagged on,
+because it needs to know your naming convention:
 
 ```ts
 // sqlgen.config.ts
 export default defineConfig({
   checkMigrationOrder: {
     enabled: true,
-    prefixPattern: /^[a-z]{4}_/, // aaaa_init.sql, aaab_add_users.sql, …
+    prefixPattern: /^\d+/, // 0001_init.sql, 0002_add_users.sql, …
   },
 });
 ```
 
-`prefixPattern` defaults to a leading run of digits (`/^\d+/`); `/^\d{14}_/` covers a
-timestamp convention. The config applies on a plain generate too, so the check holds
-whether or not CI passed the flag — and passing the flag only sets `enabled`, so a
-`prefixPattern` configured here still governs.
+Migrations apply in filename order, which is the order you meant only while every
+filename carries a sequence prefix of the same width — `1, 2, 10` applies as
+`1, 10, 2`, building a schema production never had. The check fails on a migration with
+no prefix, on two claiming the same prefix, and on prefixes of differing widths. Gaps
+are fine.
+
+Width, not "is it a number", is what's checked: equal-width prefixes sort the same way
+in any positional scheme, so a scheme that doesn't number at all is held to its own
+terms — `/^[a-z]{4}_/` for `aaaa_init.sql`, `/^\d{14}_/` for a timestamp convention.
+`prefixPattern` is required and has no default: only you know which convention your
+filenames were named for.
+
+`--check-migration-order` sets `enabled` from the CLI, for a project that wants the
+check in CI but not on every local generate:
+
+```sh
+bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order
+```
+
+The flag contributes only `enabled` and is merged over the config, so `prefixPattern`
+still has to be configured — the flag alone can't guess one.
 
 Commit the generated file and run `--check` in CI so an edited query can never
 type-check against a stale shape. The
@@ -247,8 +253,7 @@ export default defineConfig({
   transformMigration: ({ sql }) => sql.replace(/\bCONCURRENTLY\b/g, ''),
   // require every migration to be numbered 0001, 0002, … so filename order
   // (the order they apply in) is the order they were meant to run in.
-  // `prefixPattern` swaps the numeric default for your own scheme.
-  checkMigrationOrder: { enabled: true },
+  checkMigrationOrder: { enabled: true, prefixPattern: /^\d+/ },
 });
 ```
 

--- a/packages/bun-sqlgen/pkg/README.md
+++ b/packages/bun-sqlgen/pkg/README.md
@@ -163,13 +163,17 @@ instead of the default and it's held to its own terms:
 ```ts
 // sqlgen.config.ts
 export default defineConfig({
-  checkMigrationOrder: /^[a-z]{4}_/, // aaaa_init.sql, aaab_add_users.sql, …
+  checkMigrationOrder: {
+    enabled: true,
+    prefixPattern: /^[a-z]{4}_/, // aaaa_init.sql, aaab_add_users.sql, …
+  },
 });
 ```
 
-`true` uses the default numeric prefix (`/^\d+/`), which is what the CLI flag turns on;
-`/^\d{14}_/` covers a timestamp convention. The config field applies on a plain
-generate too, so the check holds whether or not CI passed the flag.
+`prefixPattern` defaults to a leading run of digits (`/^\d+/`); `/^\d{14}_/` covers a
+timestamp convention. The config applies on a plain generate too, so the check holds
+whether or not CI passed the flag — and passing the flag only sets `enabled`, so a
+`prefixPattern` configured here still governs.
 
 Commit the generated file and run `--check` in CI so an edited query can never
 type-check against a stale shape. The
@@ -242,9 +246,9 @@ export default defineConfig({
   // CONCURRENTLY can't run inside the transaction a multi-statement file applies in).
   transformMigration: ({ sql }) => sql.replace(/\bCONCURRENTLY\b/g, ''),
   // require every migration to be numbered 0001, 0002, … so filename order
-  // (the order they apply in) is the order they were meant to run in. A RegExp
-  // here replaces the numeric default with your own prefix scheme.
-  checkMigrationOrder: true,
+  // (the order they apply in) is the order they were meant to run in.
+  // `prefixPattern` swaps the numeric default for your own scheme.
+  checkMigrationOrder: { enabled: true },
 });
 ```
 

--- a/packages/bun-sqlgen/pkg/README.md
+++ b/packages/bun-sqlgen/pkg/README.md
@@ -146,18 +146,24 @@ non-zero on a problem:
 ### Migration order
 
 A fourth check guards the migrations themselves rather than the output, so it runs on a
-plain generate too and is *not* folded into `--check`. It's configured, not flagged on,
-because it needs to know your naming convention:
+plain generate too and is *not* folded into `--check`. It needs to know your naming
+convention, so you give it one — either in the config, or as the flag's value:
 
 ```ts
 // sqlgen.config.ts
 export default defineConfig({
   checkMigrationOrder: {
-    enabled: true,
     prefixPattern: /^\d+/, // 0001_init.sql, 0002_add_users.sql, …
   },
 });
 ```
+
+```sh
+bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order '^\d+'
+```
+
+Naming a pattern is what turns the check on; there is no default, because only you know
+which convention your filenames were named for. The flag overrides the config.
 
 Migrations apply in filename order, which is the order you meant only while every
 filename carries a sequence prefix of the same width — `1, 2, 10` applies as
@@ -168,18 +174,6 @@ are fine.
 Width, not "is it a number", is what's checked: equal-width prefixes sort the same way
 in any positional scheme, so a scheme that doesn't number at all is held to its own
 terms — `/^[a-z]{4}_/` for `aaaa_init.sql`, `/^\d{14}_/` for a timestamp convention.
-`prefixPattern` is required and has no default: only you know which convention your
-filenames were named for.
-
-`--check-migration-order` sets `enabled` from the CLI, for a project that wants the
-check in CI but not on every local generate:
-
-```sh
-bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order
-```
-
-The flag contributes only `enabled` and is merged over the config, so `prefixPattern`
-still has to be configured — the flag alone can't guess one.
 
 Commit the generated file and run `--check` in CI so an edited query can never
 type-check against a stale shape. The
@@ -253,7 +247,7 @@ export default defineConfig({
   transformMigration: ({ sql }) => sql.replace(/\bCONCURRENTLY\b/g, ''),
   // require every migration to be numbered 0001, 0002, … so filename order
   // (the order they apply in) is the order they were meant to run in.
-  checkMigrationOrder: { enabled: true, prefixPattern: /^\d+/ },
+  checkMigrationOrder: { prefixPattern: /^\d+/ },
 });
 ```
 

--- a/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
+++ b/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
@@ -35,6 +35,11 @@ export const command = defineCommand('generate [glob]', {
       schema: z.boolean().optional(),
       description: 'Fail if the committed generated types are out of date. Writes nothing.',
     },
+    'check-migration-order': {
+      schema: z.boolean().optional(),
+      description:
+        'Fail unless every migration filename carries a unique, consistently zero-padded sequence number (0001, 0002, … 0010). Not part of --check.',
+    },
     dialect: {
       schema: z.enum(['postgres', 'sqlite']).optional(),
       description: 'Database engine to introspect against (default postgres; overrides config).',
@@ -60,6 +65,8 @@ export const command = defineCommand('generate [glob]', {
       packageName: options.package,
       configPath: options.config,
       dialect: options.dialect,
+      // Absent, the config decides; the flag only ever turns the check on.
+      checkMigrationOrder: options['check-migration-order'] || undefined,
       // Absent, the config decides; the flag only ever turns the schema block off.
       schema: options['no-schema'] ? false : undefined,
       checkQueries,

--- a/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
+++ b/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
@@ -38,7 +38,7 @@ export const command = defineCommand('generate [glob]', {
     'check-migration-order': {
       schema: z.boolean().optional(),
       description:
-        'Fail unless every migration filename carries a unique, consistently zero-padded sequence number (0001, 0002, … 0010). Not part of --check.',
+        'Fail unless every migration filename carries a unique, equally wide sequence number (0001, 0002, … 0010). Set checkMigrationOrder in the config for a non-numeric scheme. Not part of --check.',
     },
     dialect: {
       schema: z.enum(['postgres', 'sqlite']).optional(),

--- a/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
+++ b/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
@@ -38,7 +38,7 @@ export const command = defineCommand('generate [glob]', {
     'check-migration-order': {
       schema: z.boolean().optional(),
       description:
-        'Fail unless every migration filename carries a unique, equally wide sequence number (0001, 0002, … 0010). Set checkMigrationOrder in the config for a non-numeric scheme. Not part of --check.',
+        'Fail unless every migration filename carries a unique, equally wide sequence prefix (0001, 0002, … 0010). Set checkMigrationOrder.prefixPattern in the config for a non-numeric scheme. Not part of --check.',
     },
     dialect: {
       schema: z.enum(['postgres', 'sqlite']).optional(),
@@ -65,8 +65,9 @@ export const command = defineCommand('generate [glob]', {
       packageName: options.package,
       configPath: options.config,
       dialect: options.dialect,
-      // Absent, the config decides; the flag only ever turns the check on.
-      checkMigrationOrder: options['check-migration-order'] || undefined,
+      // Absent, the config decides; the flag only ever turns the check on, and core
+      // merges it over the config so a configured `prefixPattern` survives.
+      checkMigrationOrder: options['check-migration-order'] ? { enabled: true } : undefined,
       // Absent, the config decides; the flag only ever turns the schema block off.
       schema: options['no-schema'] ? false : undefined,
       checkQueries,

--- a/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
+++ b/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
@@ -3,6 +3,15 @@ import { generate } from '@repo/bun-sqlgen-core';
 import { z } from 'zod';
 import { GenerationFailed } from '#cli/errors.ts';
 
+// The flag carries the pattern itself, so a bad one is a CLI mistake worth naming.
+function toPrefixPattern(source: string): RegExp {
+  try {
+    return new RegExp(source);
+  } catch {
+    throw new Error(`--check-migration-order is not a valid regular expression: ${source}`);
+  }
+}
+
 export const command = defineCommand('generate [glob]', {
   description:
     'Generate result types for the Bun.sql queries matching <glob> (e.g. "src/**/*.ts").',
@@ -36,9 +45,9 @@ export const command = defineCommand('generate [glob]', {
       description: 'Fail if the committed generated types are out of date. Writes nothing.',
     },
     'check-migration-order': {
-      schema: z.boolean().optional(),
+      schema: z.string().optional(),
       description:
-        'Enable the migration-order check: fail unless every migration filename carries a unique, equally wide sequence prefix. Reads its prefixPattern from checkMigrationOrder in sqlgen.config.ts, which is required. Not part of --check.',
+        'Fail unless every migration filename carries a unique sequence prefix matching <pattern>, all of one width (e.g. "^\\d+" for 0001_init.sql). Overrides config; not part of --check.',
     },
     dialect: {
       schema: z.enum(['postgres', 'sqlite']).optional(),
@@ -65,9 +74,10 @@ export const command = defineCommand('generate [glob]', {
       packageName: options.package,
       configPath: options.config,
       dialect: options.dialect,
-      // Absent, the config decides; the flag only ever turns the check on, and core
-      // merges it over the config, which is where the `prefixPattern` comes from.
-      checkMigrationOrder: options['check-migration-order'] ? { enabled: true } : undefined,
+      // Absent, the config decides — including whether the check runs at all.
+      checkMigrationOrder: options['check-migration-order']
+        ? { prefixPattern: toPrefixPattern(options['check-migration-order']) }
+        : undefined,
       // Absent, the config decides; the flag only ever turns the schema block off.
       schema: options['no-schema'] ? false : undefined,
       checkQueries,

--- a/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
+++ b/packages/bun-sqlgen/src/cli/commands/generate/[glob].ts
@@ -38,7 +38,7 @@ export const command = defineCommand('generate [glob]', {
     'check-migration-order': {
       schema: z.boolean().optional(),
       description:
-        'Fail unless every migration filename carries a unique, equally wide sequence prefix (0001, 0002, … 0010). Set checkMigrationOrder.prefixPattern in the config for a non-numeric scheme. Not part of --check.',
+        'Enable the migration-order check: fail unless every migration filename carries a unique, equally wide sequence prefix. Reads its prefixPattern from checkMigrationOrder in sqlgen.config.ts, which is required. Not part of --check.',
     },
     dialect: {
       schema: z.enum(['postgres', 'sqlite']).optional(),
@@ -66,7 +66,7 @@ export const command = defineCommand('generate [glob]', {
       configPath: options.config,
       dialect: options.dialect,
       // Absent, the config decides; the flag only ever turns the check on, and core
-      // merges it over the config so a configured `prefixPattern` survives.
+      // merges it over the config, which is where the `prefixPattern` comes from.
       checkMigrationOrder: options['check-migration-order'] ? { enabled: true } : undefined,
       // Absent, the config decides; the flag only ever turns the schema block off.
       schema: options['no-schema'] ? false : undefined,

--- a/packages/bun-sqlgen/src/config.ts
+++ b/packages/bun-sqlgen/src/config.ts
@@ -8,10 +8,11 @@ export interface MigrationOrderCheck {
   enabled: boolean;
   /**
    * What identifies a filename's sequence prefix — the part that has to be unique and
-   * equally wide across every migration. Defaults to a leading run of digits (`/^\d+/`);
-   * `/^\d{14}_/` covers a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
+   * equally wide across every migration. Required, and deliberately not defaulted: only
+   * you know which convention your migrations were named for. `/^\d+/` matches
+   * `0001_init.sql`, `/^\d{14}_/` a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
    */
-  prefixPattern?: RegExp;
+  prefixPattern: RegExp;
 }
 
 interface BaseConfig {
@@ -25,8 +26,8 @@ interface BaseConfig {
   /**
    * Fail unless every migration filename carries a unique sequence prefix, all of one
    * width — migrations apply in filename order, so `1, 2, 10` applies as `1, 10, 2`.
-   * Off unless enabled; `--check-migration-order` enables it from the CLI without
-   * discarding the `prefixPattern` set here.
+   * Off unless enabled; `--check-migration-order` enables it from the CLI, and needs
+   * the `prefixPattern` to come from here.
    */
   checkMigrationOrder?: MigrationOrderCheck;
   /** SQL run before migrations (stub functions/types/extensions). */

--- a/packages/bun-sqlgen/src/config.ts
+++ b/packages/bun-sqlgen/src/config.ts
@@ -12,11 +12,13 @@ interface BaseConfig {
    */
   schema?: boolean;
   /**
-   * Fail unless every migration filename carries a unique, consistently zero-padded
-   * sequence number — migrations apply in filename order, so `1, 2, 10` applies as
-   * `1, 10, 2`. Defaults to `false`; `--check-migration-order` turns it on from the CLI.
+   * Fail unless every migration filename carries a unique sequence prefix, all of one
+   * width — migrations apply in filename order, so `1, 2, 10` applies as `1, 10, 2`.
+   * `true` expects a numeric prefix; pass a `RegExp` for any other scheme
+   * (`/^\d{14}_/` for timestamps, `/^[a-z]{4}_/` for letters). Defaults to `false`;
+   * `--check-migration-order` turns on the numeric default from the CLI.
    */
-  checkMigrationOrder?: boolean;
+  checkMigrationOrder?: boolean | RegExp;
   /** SQL run before migrations (stub functions/types/extensions). */
   prelude?: string;
   /** Rewrite or strip statements the throwaway DB can't run, per migration file. */

--- a/packages/bun-sqlgen/src/config.ts
+++ b/packages/bun-sqlgen/src/config.ts
@@ -3,6 +3,17 @@ import type { Extensions } from '@electric-sql/pglite';
 /** Which engine introspects the migrations at build time. Defaults to `postgres`. */
 export type Dialect = 'postgres' | 'sqlite';
 
+/** Settings for the migration-order check. */
+export interface MigrationOrderCheck {
+  enabled: boolean;
+  /**
+   * What identifies a filename's sequence prefix — the part that has to be unique and
+   * equally wide across every migration. Defaults to a leading run of digits (`/^\d+/`);
+   * `/^\d{14}_/` covers a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
+   */
+  prefixPattern?: RegExp;
+}
+
 interface BaseConfig {
   /** Database engine the queries run against. Defaults to `postgres`. */
   dialect?: Dialect;
@@ -14,11 +25,10 @@ interface BaseConfig {
   /**
    * Fail unless every migration filename carries a unique sequence prefix, all of one
    * width — migrations apply in filename order, so `1, 2, 10` applies as `1, 10, 2`.
-   * `true` expects a numeric prefix; pass a `RegExp` for any other scheme
-   * (`/^\d{14}_/` for timestamps, `/^[a-z]{4}_/` for letters). Defaults to `false`;
-   * `--check-migration-order` turns on the numeric default from the CLI.
+   * Off unless enabled; `--check-migration-order` enables it from the CLI without
+   * discarding the `prefixPattern` set here.
    */
-  checkMigrationOrder?: boolean | RegExp;
+  checkMigrationOrder?: MigrationOrderCheck;
   /** SQL run before migrations (stub functions/types/extensions). */
   prelude?: string;
   /** Rewrite or strip statements the throwaway DB can't run, per migration file. */

--- a/packages/bun-sqlgen/src/config.ts
+++ b/packages/bun-sqlgen/src/config.ts
@@ -3,14 +3,13 @@ import type { Extensions } from '@electric-sql/pglite';
 /** Which engine introspects the migrations at build time. Defaults to `postgres`. */
 export type Dialect = 'postgres' | 'sqlite';
 
-/** Settings for the migration-order check. */
+/** Settings for the migration-order check; its presence is what turns the check on. */
 export interface MigrationOrderCheck {
-  enabled: boolean;
   /**
    * What identifies a filename's sequence prefix — the part that has to be unique and
-   * equally wide across every migration. Required, and deliberately not defaulted: only
-   * you know which convention your migrations were named for. `/^\d+/` matches
-   * `0001_init.sql`, `/^\d{14}_/` a timestamp scheme, `/^[a-z]{4}_/` a lettered one.
+   * equally wide across every migration. Not defaulted: only you know which convention
+   * your filenames were named for. `/^\d+/` matches `0001_init.sql`, `/^\d{14}_/` a
+   * timestamp scheme, `/^[a-z]{4}_/` a lettered one.
    */
   prefixPattern: RegExp;
 }
@@ -26,8 +25,7 @@ interface BaseConfig {
   /**
    * Fail unless every migration filename carries a unique sequence prefix, all of one
    * width — migrations apply in filename order, so `1, 2, 10` applies as `1, 10, 2`.
-   * Off unless enabled; `--check-migration-order` enables it from the CLI, and needs
-   * the `prefixPattern` to come from here.
+   * Omit it and the check doesn't run; `--check-migration-order <pattern>` overrides it.
    */
   checkMigrationOrder?: MigrationOrderCheck;
   /** SQL run before migrations (stub functions/types/extensions). */

--- a/packages/bun-sqlgen/src/config.ts
+++ b/packages/bun-sqlgen/src/config.ts
@@ -11,6 +11,12 @@ interface BaseConfig {
    * constraint names. Defaults to `true`; `--no-schema` turns it off from the CLI.
    */
   schema?: boolean;
+  /**
+   * Fail unless every migration filename carries a unique, consistently zero-padded
+   * sequence number — migrations apply in filename order, so `1, 2, 10` applies as
+   * `1, 10, 2`. Defaults to `false`; `--check-migration-order` turns it on from the CLI.
+   */
+  checkMigrationOrder?: boolean;
   /** SQL run before migrations (stub functions/types/extensions). */
   prelude?: string;
   /** Rewrite or strip statements the throwaway DB can't run, per migration file. */


### PR DESCRIPTION
Migrations apply in filename order, and that is the order you meant only while every filename carries a sequence prefix of the same width — `1, 2, 10` applies as `1, 10, 2`, silently building a schema production never had.

Naming a prefix pattern is what turns the check on — in the config, or as the flag's value:

```ts
// sqlgen.config.ts
export default defineConfig({
  checkMigrationOrder: { prefixPattern: /^\d+/ }, // 0001_init.sql, 0002_add_users.sql, …
});
```

```sh
bun bun-sqlgen generate 'src/**/*.ts' --migrations db/migrations --check-migration-order '^\d+'
```

There's no default pattern: only the project knows which convention its filenames were named for, and a wrong guess passes a check that never looked at the right prefix.

Width, not "is it a number", is what's checked: equal-width prefixes sort the same way in any positional scheme, so a scheme that doesn't number at all is held to its own terms (`/^[a-z]{4}_/`, `/^\d{14}_/`). It fails on a migration with no prefix, on two claiming the same prefix (`0035` twice), and on prefixes of differing widths. Gaps are fine.

Deliberately **not** folded into `--check`: unlike the other checks it guards generation itself rather than the output, so it runs in every mode — and folding it in would break CI for projects with unprefixed migrations that work fine today.
