### PR TITLE
fix: layer a view's column comment over the base column's

### DIFF
--- a/examples/simple/src/db/migrations/0009_view_comment_layering.sql
+++ b/examples/simple/src/db/migrations/0009_view_comment_layering.sql
@@ -1,0 +1,24 @@
+CREATE TABLE deployments (
+  id     bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  state  text NOT NULL,
+  digest text
+);
+
+-- The table brands `state` and pins `digest`, which the catalog reports nullable.
+COMMENT ON COLUMN deployments.state IS
+  'Lifecycle state. @type ''pending'' | ''running'' | ''failed''';
+COMMENT ON COLUMN deployments.digest IS 'Content hash of the built image. @notNull';
+
+CREATE VIEW desired_deployments AS
+SELECT
+  id     AS deployment_id,
+  state  AS deployment_state,
+  digest AS deployment_digest
+FROM deployments;
+
+-- A view comment carrying only prose layers over the base column's rather than
+-- replacing it: the doc is the view's, the `@type` and the `@notNull` still the table's.
+COMMENT ON COLUMN desired_deployments.deployment_state IS
+  'The release''s own state, beside the app''s.';
+COMMENT ON COLUMN desired_deployments.deployment_digest IS
+  'Digest the release should converge on.';

--- a/examples/simple/src/index.ts
+++ b/examples/simple/src/index.ts
@@ -60,6 +60,14 @@ const dealDetails = await sql.ListDealDetails`
 console.log(dealDetails[0]?.status_upper); // string
 console.log(dealDetails[0]?.status); // 'draft' | 'won' | 'lost' — the view's own comment
 
+// A view comment carrying only prose layers over the base column's instead of replacing
+// it: the JSDoc is the view's, the `@type` and the `@notNull` still the table's.
+const desired = await sql.ListDesiredDeployments`
+  SELECT deployment_state, deployment_digest FROM desired_deployments
+`;
+console.log(desired[0]?.deployment_state === 'failed'); // 'pending' | 'running' | 'failed'
+console.log(desired[0]?.deployment_digest.length); // string — not null, per the base column
+
 // Composition: the `byStatus` fragment is inlined, its param numbered before the outer one.
 const byStatus = sql`status = ${'won'}`;
 const search = await sql.SearchDeals`

--- a/examples/simple/src/queries.gen.ts
+++ b/examples/simple/src/queries.gen.ts
@@ -40,6 +40,14 @@ export interface IListDealDetailsResult {
     status_upper: string;
 }
 
+/** Result of query `ListDesiredDeployments`. */
+export interface IListDesiredDeploymentsResult {
+    /** The release's own state, beside the app's. */
+    deployment_state: IDeploymentsColumns["state"];
+    /** Digest the release should converge on. */
+    deployment_digest: IDeploymentsColumns["digest"];
+}
+
 /** Result of query `SearchDeals`. */
 export interface ISearchDealsResult {
     id: IDealsColumns["id"];
@@ -110,6 +118,7 @@ export interface Queries {
     ListDeals: IListDealsResult;
     GetDealSummaries: IGetDealSummariesResult;
     ListDealDetails: IListDealDetailsResult;
+    ListDesiredDeployments: IListDesiredDeploymentsResult;
     SearchDeals: ISearchDealsResult;
     RecentDeals: IRecentDealsResult;
     GetDealMeta: IGetDealMetaResult;
@@ -180,6 +189,40 @@ export interface IDealsTable {
     relationType: (typeof schema)["deals"]["_relationType"];
     indexes: keyof (typeof schema)["deals"]["_indexes"];
     constraints: keyof (typeof schema)["deals"]["_constraints"];
+}
+
+/** Columns of `deployments`. */
+export interface IDeploymentsColumns {
+    id: string;
+    /** Lifecycle state. */
+    state: "pending" | "running" | "failed";
+    /** Content hash of the built image. */
+    digest: string;
+}
+
+/** Schema of `deployments`. */
+export interface IDeploymentsTable {
+    columns: IDeploymentsColumns;
+    relationType: (typeof schema)["deployments"]["_relationType"];
+    indexes: keyof (typeof schema)["deployments"]["_indexes"];
+    constraints: keyof (typeof schema)["deployments"]["_constraints"];
+}
+
+/** Columns of `desired_deployments`. */
+export interface IDesiredDeploymentsColumns {
+    deployment_id: string | null;
+    /** The release's own state, beside the app's. */
+    deployment_state: string | null;
+    /** Digest the release should converge on. */
+    deployment_digest: string | null;
+}
+
+/** Schema of `desired_deployments`. */
+export interface IDesiredDeploymentsTable {
+    columns: IDesiredDeploymentsColumns;
+    relationType: (typeof schema)["desired_deployments"]["_relationType"];
+    indexes: keyof (typeof schema)["desired_deployments"]["_indexes"];
+    constraints: keyof (typeof schema)["desired_deployments"]["_constraints"];
 }
 
 /** Columns of `payments`. */
@@ -299,6 +342,32 @@ export const schema = {
             deals_user_id_fkey: { _constraintName: "deals_user_id_fkey" }
         }
     },
+    deployments: {
+        _relationName: "deployments",
+        _relationType: "table",
+        _columns: {
+            id: { _columnName: "id", _foreignKeys: {} },
+            state: { _columnName: "state", _foreignKeys: {} },
+            digest: { _columnName: "digest", _foreignKeys: {} }
+        },
+        _indexes: {
+            deployments_pkey: { _indexName: "deployments_pkey" }
+        },
+        _constraints: {
+            deployments_pkey: { _constraintName: "deployments_pkey" }
+        }
+    },
+    desired_deployments: {
+        _relationName: "desired_deployments",
+        _relationType: "view",
+        _columns: {
+            deployment_id: { _columnName: "deployment_id", _foreignKeys: {} },
+            deployment_state: { _columnName: "deployment_state", _foreignKeys: {} },
+            deployment_digest: { _columnName: "deployment_digest", _foreignKeys: {} }
+        },
+        _indexes: {},
+        _constraints: {}
+    },
     payments: {
         _relationName: "payments",
         _relationType: "table",
@@ -371,6 +440,8 @@ export interface Tables {
     deal_details: IDealDetailsTable;
     deal_meta: IDealMetaTable;
     deals: IDealsTable;
+    deployments: IDeploymentsTable;
+    desired_deployments: IDesiredDeploymentsTable;
     payments: IPaymentsTable;
     tenant_notes: ITenantNotesTable;
     tenants: ITenantsTable;

--- a/packages/bun-sqlgen-core/src/nullability.ts
+++ b/packages/bun-sqlgen-core/src/nullability.ts
@@ -21,9 +21,9 @@ import type {
  * non-null iff it's NOT NULL *and* not on the nullable side of an outer join;
  * anything untraceable (expressions, aggregates, casts) is conservatively
  * nullable. Precedence: per-query `@notNull`/`@nullable` win, then the column's own
- * `COMMENT ON COLUMN` markers — the view's, where the query selected through one —
- * then the catalog/introspector defaults. The base TS type comes from the introspector
- * (`f.ts`); a column comment's `@type` overrides it.
+ * `COMMENT ON COLUMN` markers — where the query selected through a view, that view's
+ * layered over the base column's — then the catalog/introspector defaults. The base TS
+ * type comes from the introspector (`f.ts`); a column comment's `@type` overrides it.
  */
 export function resolveFields(input: {
   described: Pick<DescribeResult, 'fields' | 'provenance' | 'relations' | 'views'>;
@@ -38,7 +38,8 @@ export function resolveFields(input: {
     const prov = described.provenance?.[i];
     const source = resolveSource({ prov, catalog });
     // A query naming a view asked for the view's column, whatever the plan rewrote it
-    // into — so a comment on that column outranks the one on the base column beneath it.
+    // into — so a comment on that column outranks the one on the base column beneath it,
+    // marker by marker.
     const view = viewOverride({
       name: f.name,
       source,
@@ -46,21 +47,19 @@ export function resolveFields(input: {
       viewColumns: input.viewColumns,
       columnOverrides,
     });
-    // Otherwise a column comment matched either via provenance, or — for fields the
+    // The base column's comment, matched either via provenance, or — for fields the
     // planner emits as expressions (e.g. VIRTUAL generated columns) — by name within a
     // single in-scope relation.
-    const comment: ColumnOverride | undefined =
-      view?.override ??
-      (source
-        ? columnOverrides[source.table]?.[source.column]
-        : commentByName({
-            name: f.name,
-            // An expression that traced to one relation names its owner; otherwise every
-            // relation in scope is a candidate and only an unambiguous match counts.
-            relations:
-              prov?.kind === 'expr' && prov.relation ? [prov.relation] : described.relations,
-            columnOverrides,
-          }));
+    const base: ColumnOverride | undefined = source
+      ? columnOverrides[source.table]?.[source.column]
+      : commentByName({
+          name: f.name,
+          // An expression that traced to one relation names its owner; otherwise every
+          // relation in scope is a candidate and only an unambiguous match counts.
+          relations: prov?.kind === 'expr' && prov.relation ? [prov.relation] : described.relations,
+          columnOverrides,
+        });
+    const comment = layerComment({ view: view?.override, base });
 
     // A per-query `@type` is the most specific override there is: it names the exact
     // result column and gives its full TS type verbatim (nullability included), so it
@@ -126,8 +125,8 @@ export function resolveFields(input: {
       doc: comment?.doc,
       // The reference the emitter writes has to name a relation whose schema-block
       // column carries this type. A view's `@type` retypes only the view's entry, so
-      // that's the one to point at; without one, both agree and the base column — the
-      // more telling provenance — stays.
+      // that's the one to point at; without one the type came from the base column —
+      // its own `@type` or the introspector — and that's the entry that carries it.
       source: (view?.override.tsType ? view.column : source) ?? undefined,
     };
   });
@@ -219,6 +218,30 @@ function viewOverride(input: {
       matching((c) => c.source?.table === source.table && c.source.column === source.column)) ??
     matching((c) => c.column === input.name)
   );
+}
+
+/**
+ * A view column's comment layered over the base column's: each marker wins where the
+ * view declares one and falls through to the base column's where it doesn't, so a view
+ * comment carrying only prose documents the column without untyping it. `@notNull` and
+ * `@nullable` fall through together — a view declaring either has answered the question,
+ * and its answer replaces the base column's rather than sitting beside it.
+ */
+function layerComment(input: {
+  view: ColumnOverride | undefined;
+  base: ColumnOverride | undefined;
+}): ColumnOverride | undefined {
+  const { view, base } = input;
+  if (!view || !base) {
+    return view ?? base;
+  }
+  const nullability = view.notNull || view.nullable ? view : base;
+  return {
+    notNull: nullability.notNull,
+    nullable: nullability.nullable,
+    tsType: view.tsType ?? base.tsType,
+    doc: view.doc ?? base.doc,
+  };
 }
 
 // A comment override for a field name owned by exactly one in-scope relation.


### PR DESCRIPTION
Fixes #34.

A view's column comment replaced the base column's override instead of layering over it, so a prose-only view comment dropped the base column's `@type` (and, the same way, its `@notNull`). Each marker now wins where the view declares it and falls through to the base column's where it doesn't; `@notNull`/`@nullable` fall through as a pair.

`examples/simple` gains a fixture that reproduces it — without the fix the two new fields come out `string` and `string | null` instead of `IDeploymentsColumns["state"]` and `IDeploymentsColumns["digest"]`.

The **schema block** for a view column has the same gap, pre-existing rather than a `0.6.1` regression, and is left alone here: #36 stacks on this branch and fixes it.