### PR TITLE
fix: layer the base column's comment into a view's schema entry

### DIFF
--- a/examples/simple/src/db/migrations/0010_view_inherited_column.sql
+++ b/examples/simple/src/db/migrations/0010_view_inherited_column.sql
@@ -1,0 +1,13 @@
+ALTER TABLE deployments ADD COLUMN config jsonb;
+COMMENT ON COLUMN deployments.config IS
+  'Rendered deploy config. @type { replicas: number }';
+
+-- The view exposes it without commenting it at all: the schema block's entry for
+-- `deployment_config` inherits both the `@type` and the prose from the base column.
+CREATE OR REPLACE VIEW desired_deployments AS
+SELECT
+  id     AS deployment_id,
+  state  AS deployment_state,
+  digest AS deployment_digest,
+  config AS deployment_config
+FROM deployments;

--- a/examples/simple/src/index.ts
+++ b/examples/simple/src/index.ts
@@ -182,6 +182,24 @@ console.log(kind);
 const noIndex: DatabaseTables['deal_details']['indexes'] = 'anything';
 console.log(noIndex);
 
+// A view column's own schema entry layers over the base column's comment the same way a
+// query through the view does, so both report one type — and `deployment_config`, which
+// the view doesn't comment at all, inherits the base column's `@type` and JSDoc outright.
+// Nullability stays the view's answer: a view is free to LEFT JOIN, and nothing tracks
+// `NOT NULL` through one, so the pinned `deployments.digest` is still nullable here.
+type DesiredDeploymentRow = DatabaseTables['desired_deployments']['columns'];
+const desiredRow: DesiredDeploymentRow = {
+  deployment_id: '1',
+  deployment_state: 'running',
+  deployment_digest: null,
+  deployment_config: { replicas: 2 },
+};
+console.log(desiredRow.deployment_state, desiredRow.deployment_config?.replicas);
+
+// @ts-expect-error — `deployment_state` carries the base column's `@type`, not `string`
+const badState: DesiredDeploymentRow = { ...desiredRow, deployment_state: 'nope' };
+console.log(badState);
+
 // Foreign keys hang off the column they constrain, so a reference can be followed
 // without knowing the constraint's name up front.
 const dealsToUsers = schema.deals._columns.user_id._foreignKeys.deals_user_id_fkey;

--- a/examples/simple/src/queries.gen.ts
+++ b/examples/simple/src/queries.gen.ts
@@ -198,6 +198,10 @@ export interface IDeploymentsColumns {
     state: "pending" | "running" | "failed";
     /** Content hash of the built image. */
     digest: string;
+    /** Rendered deploy config. */
+    config: {
+        replicas: number;
+    } | null;
 }
 
 /** Schema of `deployments`. */
@@ -212,9 +216,13 @@ export interface IDeploymentsTable {
 export interface IDesiredDeploymentsColumns {
     deployment_id: string | null;
     /** The release's own state, beside the app's. */
-    deployment_state: string | null;
+    deployment_state: "pending" | "running" | "failed" | null;
     /** Digest the release should converge on. */
     deployment_digest: string | null;
+    /** Rendered deploy config. */
+    deployment_config: {
+        replicas: number;
+    } | null;
 }
 
 /** Schema of `desired_deployments`. */
@@ -348,7 +356,8 @@ export const schema = {
         _columns: {
             id: { _columnName: "id", _foreignKeys: {} },
             state: { _columnName: "state", _foreignKeys: {} },
-            digest: { _columnName: "digest", _foreignKeys: {} }
+            digest: { _columnName: "digest", _foreignKeys: {} },
+            config: { _columnName: "config", _foreignKeys: {} }
         },
         _indexes: {
             deployments_pkey: { _indexName: "deployments_pkey" }
@@ -363,7 +372,8 @@ export const schema = {
         _columns: {
             deployment_id: { _columnName: "deployment_id", _foreignKeys: {} },
             deployment_state: { _columnName: "deployment_state", _foreignKeys: {} },
-            deployment_digest: { _columnName: "deployment_digest", _foreignKeys: {} }
+            deployment_digest: { _columnName: "deployment_digest", _foreignKeys: {} },
+            deployment_config: { _columnName: "deployment_config", _foreignKeys: {} }
         },
         _indexes: {},
         _constraints: {}

--- a/packages/bun-sqlgen-core/src/generate.ts
+++ b/packages/bun-sqlgen-core/src/generate.ts
@@ -162,7 +162,7 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
     tables = emitSchema
       ? (await intro.tables()).map((table) => ({
           ...table,
-          columns: resolveTableColumns({ table, columnOverrides }),
+          columns: resolveTableColumns({ table, columnOverrides, viewColumns }),
         }))
       : [];
 

--- a/packages/bun-sqlgen-core/src/nullability.ts
+++ b/packages/bun-sqlgen-core/src/nullability.ts
@@ -135,16 +135,26 @@ export function resolveFields(input: {
 /**
  * The same resolution for a base relation's own columns: a column comment's `@type`
  * overrides the introspector's type, its `@notNull`/`@nullable` override the schema's,
- * and its prose becomes the field's JSDoc. No query is in scope here, so there are no
+ * and its prose becomes the field's JSDoc. A view's column layers over the base column
+ * it passes through, as it does in a query. No query is in scope here, so there are no
  * per-query pragmas and no outer-join widening — just the column as the schema declares it.
  */
 export function resolveTableColumns(input: {
   table: SchemaTable;
   columnOverrides: ColumnOverrides;
+  viewColumns: ViewColumns;
 }): EmitColumn[] {
   const overrides = input.columnOverrides[input.table.name] ?? {};
+  // What each column passes through, for a view; a table passes through nothing.
+  const passThrough = new Map(
+    (input.viewColumns[input.table.name] ?? []).map((c) => [c.column, c.source]),
+  );
   return input.table.columns.map((column): EmitColumn => {
-    const comment = overrides[column.name];
+    const source = passThrough.get(column.name);
+    const comment = layerComment({
+      view: overrides[column.name],
+      base: inherited(source && input.columnOverrides[source.table]?.[source.column]),
+    });
     const { ts, note } = commentType({ base: column, comment });
     return {
       name: column.name,
@@ -242,6 +252,17 @@ function layerComment(input: {
     tsType: view.tsType ?? base.tsType,
     doc: view.doc ?? base.doc,
   };
+}
+
+/**
+ * The part of a base column's comment a view column inherits in the schema block: the
+ * value reaches the view unchanged, so `@type` and the prose travel with it. `@notNull`
+ * doesn't — a view is free to `LEFT JOIN`, and a relation's own columns are resolved
+ * with no query in scope, so nothing here could tell that it hasn't. Queries selecting
+ * through the view do carry it: they have the plan, and its outer joins, to widen by.
+ */
+function inherited(base: ColumnOverride | undefined): ColumnOverride | undefined {
+  return base?.tsType || base?.doc ? { tsType: base.tsType, doc: base.doc } : undefined;
 }
 
 // A comment override for a field name owned by exactly one in-scope relation.


### PR DESCRIPTION
Stacked on #35 — review that one first; this diff is only the last commit.

#35 fixed the query side of #34. The schema block had the same gap, and still does after it: a view's columns are typed from `columnOverrides[view]` alone, never reaching the comment on the base column each one passes through. With #35's fixture that shows up as `IDesiredDeploymentsColumns["deployment_state"]` reading `string | null` while a query selecting the same column through the view reads `"pending" | "running" | "failed"` — two answers in one generated file.

`resolveTableColumns` now takes the `viewColumns` map `generate` already builds and layers through the same `layerComment` as the query resolver. **Only `@type` and the prose are inherited** — not `@notNull`: a view is free to `LEFT JOIN`, and a relation's own columns are resolved with no query (no plan, no joins) in scope, so nothing there could tell that it hasn't. Queries keep carrying it, since they have the plan's outer joins to widen by, and view columns stay all-nullable as `pkg/README.md` documents.

Locked in `examples/simple`: `deployments.config` is `@type`'d and exposed through the view with no comment on the view column at all, and the view's row type is asserted against `DatabaseTables` — the `@ts-expect-error` on `deployment_state` stops compiling if the brand widens back to `string`.